### PR TITLE
Updates for EOmaps v6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "EOmaps" %}
-{% set version = "5.4" %}
+{% set version = "6.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/EOmaps-{{ version }}.tar.gz
-  sha256: 7116314c30a8e5e6caf012c8ac779fe9239f051af2e098bfbe688df454197ab8
+  sha256: d6593fa45632b0e3afbd3713449ec913e2d6d258920e337a95199ad62d98b480
 build:
   number: 0
   noarch: python
@@ -22,7 +22,7 @@ requirements:
     - numpy
     - scipy
     - pandas
-    - matplotlib-base >=3.0
+    - matplotlib >=3.0
     - cartopy >=0.20.0
     - descartes
     - mapclassify


### PR DESCRIPTION
require matplotlib instead of matplotlib-base since QT is now an integral part

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
